### PR TITLE
Allow value definitions with commas in them.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ var _icssReplaceSymbols = require('icss-replace-symbols');
 var _icssReplaceSymbols2 = _interopRequireDefault(_icssReplaceSymbols);
 
 var matchImports = /^(.+?)\s+from\s+("[^"]*"|'[^']*'|[\w-]+)$/;
-var matchValueDefinition = /(?:,\s+|^)([\w-]+):?\s+("[^"]*"|'[^']*'|\w+\([^\)]+\)|[^,]+)\s?/g;
+var matchValueDefinition = /(?:\s+|^)([\w-]+):?\s+(.+?)\s*$/g;
 var matchImport = /^([\w-]+)(?:\s+as\s+([\w-]+))?/;
 var options = {};
 var importIndex = 0;

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import postcss from 'postcss'
 import replaceSymbols, { replaceAll } from 'icss-replace-symbols'
 
 const matchImports = /^(.+?)\s+from\s+("[^"]*"|'[^']*'|[\w-]+)$/
-const matchValueDefinition = /(?:,\s+|^)([\w-]+):?\s+("[^"]*"|'[^']*'|\w+\([^\)]+\)|[^,]+)\s?/g
+const matchValueDefinition = /(?:\s+|^)([\w-]+):?\s+(.+?)\s*$/g
 const matchImport = /^([\w-]+)(?:\s+as\s+([\w-]+))?/
 let options = {}
 let importIndex = 0

--- a/test/index.js
+++ b/test/index.js
@@ -110,4 +110,12 @@ describe('constants', () => {
       ':export {\n  named: red;\n  3char: #0f0;\n  6char: #00ff00;\n  rgba: rgba(34, 12, 64, 0.3);\n  hsla: hsla(220, 13.0%, 18.0%, 1);\n}\n' +
       '.foo { color: red; background-color: #0f0; border-top-color: #00ff00; border-bottom-color: rgba(34, 12, 64, 0.3); outline-color: hsla(220, 13.0%, 18.0%, 1); }')
   })
+
+  it('should allow definitions with commas in them', () => {
+    test(
+      '@value coolShadow: 0 11px 15px -7px rgba(0,0,0,.2),0 24px 38px 3px rgba(0,0,0,.14)   ;\n' +
+      '.foo { box-shadow: coolShadow; }',
+      ':export {\n  coolShadow: 0 11px 15px -7px rgba(0,0,0,.2),0 24px 38px 3px rgba(0,0,0,.14);\n}\n' +
+      '.foo { box-shadow: 0 11px 15px -7px rgba(0,0,0,.2),0 24px 38px 3px rgba(0,0,0,.14); }')
+  })
 })


### PR DESCRIPTION
Feel free to tell me that this is dumb and I shouldn't be using values this way, but one thing I've wanted to use values for was to reuse some box-shadow definitions that contain multiple shadows. Declaring a box-shadow looks something like this:

``` css
.foo {
  box-shadow: 0 11px 15px -7px rgba(0,0,0,.2),
      0 24px 38px 3px rgba(0,0,0,.14);
}
```

I'd like to save the whole definition in a value, so that other modules that import that value don't have to e.g. know how many shadows it contains or the specifics about their structure:

``` css
@value myShadow: 0 11px 15px -7px rgba(0,0,0,.2), 0 24px 38px 3px rgba(0,0,0,.14);
.foo {
  box-shadow: myShadow;
}
```

Currently with this module, however, that's not possible, as value defintions cannot contain commas (except when they are inside parentheses). This can also cause problems with trying to define other multiple-value things, such as media query conditions (see #11 for other examples as well). I realize that I could also re-use box-shadow by composing a class that has that value set, but class composition doesn't always work perfectly for all purposes (i.e. when I need to apply a particular property value when an element is `:active`).

This PR makes the syntax for value definitions more permissive, essentially allowing _anything_ to be contained in the actual value. To do so, it makes value _declarations_ slightly more strict by removing the ability to declare multiple values within one `@value` statement.

i.e. before this PR:

``` css
@value foo: 7, bar: 8;
```

would give two values, `foo` and `bar`. After this PR, it would give only a single value, `foo`. (Imports still work as before, and multiple values can be imported with a single `@value` statement). This feature doesn't seem to be documented anywhere, so I'm not sure that its widely used anyway.

The benefit here is that values can now contain multiple comma-seperated items, which is very useful for reusing things like:
- Multiple box-shadow shadows
- Multiple transition specifications
- Multiple media query conditions (OR'd)

It does allow for a little bit of weirder usage in this, e.g. for specifying a  subset of items  in a comma-separated rgba value:

``` css
@value redAndGreen: 150, 150;
.foo { background-color: rgba(redAndGreen, 0, 1); }
```

I don't think that's a super-desirable usage, but I also don't think it really harms anything by being allowed, so I haven't attempted to mitigate it.

I think that allowing multiple value declarations in a single `@value` statement is possible to preserve while still allowing for comma-separate values, but would probably involve moving to an actual parser (doubtful that it can really be done in a regular expression). It might also involve mandating ':' usage, which seems to be undesirable for SASS compatibility
