### PR TITLE
Emit warnings when multiple @value rules don't end in a semicolon

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ let options = {}
 let importIndex = 0
 let createImportedName = options && options.createImportedName || ((importName/*, path*/) => `i__const_${importName.replace(/\W/g, '_')}_${importIndex++}`)
 
-export default css => {
+export default (css, result) => {
   let importAliases = []
   let definitions = {}
 
@@ -49,6 +49,10 @@ export default css => {
     if (matchImports.exec(atRule.params)) {
       addImport(atRule)
     } else {
+      if (atRule.params.indexOf('@value') !== -1) {
+        result.warn('Invalid value definition: ' + atRule.params)
+      }
+
       addDefinition(atRule)
     }
   })

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,16 @@ describe('constants', () => {
     test('@value red blue;', ':export {\n  red: blue\n}')
   })
 
+  it('gives an error when there is no semicolon between lines', () => {
+    const input = '@value red blue\n@value green yellow'
+    let processor = postcss([constants])
+    const result = processor.process(input)
+    const warnings = result.warnings()
+
+    assert.equal(warnings.length, 1)
+    assert.equal(warnings[0].text, 'Invalid value definition: red blue\n@value green yellow')
+  })
+
   it('should export a more complex constant', () => {
     test('@value small (max-width: 599px);', ':export {\n  small: (max-width: 599px)\n}')
   })


### PR DESCRIPTION
With this update the plugin will warn about things like this:

```
@value red blue
@value green yellow
```

The missing semicolon will cause the 2nd line to be considered part of the 1st `@value`.  With the update we'll warn the user: `Invalid value definition: red blue\n@value green yellow`
