### PR TITLE
Replace .npmignore with `files`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git+https://github.com/css-modules/postcss-modules-constants.git"
   },
+  "files": [
+    "lib"
+  ],
   "keywords": [
     "css",
     "modules",


### PR DESCRIPTION
Only publish essential files to npm.
Remove the redundant `.npmignore` file.

https://docs.npmjs.com/files/package.json#files
